### PR TITLE
Added a case for arrays to deepClone and added test

### DIFF
--- a/src/scripts/__tests__/collection.js
+++ b/src/scripts/__tests__/collection.js
@@ -1,4 +1,6 @@
 const Coll = require('../collection')
+const { isArr } = require('../array')
+const { isObj } = require('../object')
 
 describe('/collection', () => {
 
@@ -207,6 +209,25 @@ describe('/collection', () => {
       expect(clone[0]).toEqual('foo')
       expect(clone[1]).toEqual('bar')
       
+    })
+
+    describe('preserving the source types when cloning', () => {
+      class Foo {}
+      const testCases = [
+        [[], isArr], 
+        [{}, isObj],
+        [1, Number.isInteger ],
+        [new Foo(), x => (x instanceof Foo)],
+        [new Date(), x => (x instanceof Date)],
+        ["hi", x => (typeof x === 'string')],
+      ]
+
+      testCases.map(([source, predicate], idx) => {
+        it(`should preserve the source type for test case ${idx}`, () => {
+          const clone = Coll.deepClone(source)
+          expect(predicate(clone)).toBe(true)
+        })
+      })
     })
 
     it('should create a deep copy of the passed in object collection', () => {

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -179,7 +179,7 @@ export const set = (obj, path, val) => (
 export const unset = (obj, path) => updateColl(obj, path, 'unset')
 
 /**
- * Recursively clones am object or array.
+ * Recursively clones an object or array.
   * @example
  * const test = { foo: [ { bar: 'baz' } ] }
  * const clone = deepClone(test)
@@ -196,6 +196,7 @@ export const deepClone = (obj, hash = new WeakMap()) => {
   if (Object(obj) !== obj) return obj
   if (obj instanceof Set) return new Set(obj)
   if (hash.has(obj)) return hash.get(obj)
+  if (isArr(obj)) return obj.map(x => deepClone(x))
 
   const result = obj instanceof Date 
     ? new Date(obj)


### PR DESCRIPTION
- my previous solution cloned arrays as plain objects with their prototype set to Array
- this fix ensures they remain **arrays**, while still being deeply cloned
- added a test case that verifies multiple types are preserved after cloning