### PR TITLE
mapEntries and filterObj updates, omitRange

### DIFF
--- a/src/scripts/__tests__/array.js
+++ b/src/scripts/__tests__/array.js
@@ -1,4 +1,4 @@
-const Array = require('../array')
+const Arr = require('../array')
 
 describe('/array', () => {
 
@@ -34,4 +34,53 @@ describe('/array', () => {
 
   })
 
+  describe('omitRange', () => {
+    let originalConsole
+    beforeEach(() => {
+      originalConsole = console.error
+    })
+
+    afterEach(() => {
+      console.error = originalConsole
+    })
+
+    it('should return a new array with the range omitted', () => {
+      const array = Object.freeze([1,2,3,4,5])
+      const newArray = Arr.omitRange(array, 1, 2)
+      expect(array).toEqual([1,2,3,4,5])
+      expect(newArray).not.toBe(array)
+      expect(newArray).toEqual([1,4,5])
+    })
+
+    it('should work with a count exceeding the length of the array', () => {
+      const array = Object.freeze([1,2,3,4,5])
+      const newArray = Arr.omitRange(array, 0, 9)
+      expect(array).toEqual([1,2,3,4,5])
+      expect(newArray).toEqual([])
+    })
+
+    it("should console error when passing in something other than an array", () => {
+      console.error = jest.fn()
+      const result = Arr.omitRange(1, 2, 3) 
+      expect(result).toEqual(1)
+      expect(console.error).toBeCalled()
+    })
+
+    it("should console error with invalid range input", () => {
+
+      const cases = [
+        [['x'], -1, 1],
+        [['x'], 1, -1],
+        [['x'], null, 1],
+        [['x'], 1, null]
+      ]
+
+      cases.forEach(([arr, start, count]) => {
+        console.error = jest.fn()
+        const result = Arr.omitRange(arr, start, count) 
+        expect(result).toEqual(['x'])
+        expect(console.error).toBeCalled()
+      })
+    })
+  })
 })

--- a/src/scripts/__tests__/array.js
+++ b/src/scripts/__tests__/array.js
@@ -12,8 +12,15 @@ describe('/array', () => {
 
   describe('isArr', () => {
 
-    it('should ', () => {})
-
+    it('should check for arrays', () => {
+      expect(Arr.isArr([1,2])).toBe(true)
+      expect(Arr.isArr([])).toBe(true)
+      expect(Arr.isArr({})).toBe(false)
+      expect(Arr.isArr("hi")).toBe(false)
+      expect(Arr.isArr(1)).toBe(false)
+      expect(Arr.isArr(null)).toBe(false)
+      expect(Arr.isArr(new Set())).toBe(false)
+    })
   })
 
   describe('randomArray', () => {

--- a/src/scripts/__tests__/object.js
+++ b/src/scripts/__tests__/object.js
@@ -1,4 +1,5 @@
 const Obj = require('../object')
+const { isArr } = require('../array')
 
 describe('/object', () => {
 
@@ -426,6 +427,55 @@ describe('/object', () => {
       expect(Obj.filterObj(aString, () => {})).toEqual(aString)
       expect(Obj.filterObj({}, null)).toEqual({})
       expect(outputArr.length).toEqual(2)
+      console.error = orgError
+    })
+  })
+
+  describe('mapEntries', () => {
+    it('should work with objects and return an object', () => {
+      const obj = {a: 1, b: 2, c: 3}
+      const expected = {a: 1, b: 4, c: 9}
+      const result = Obj.mapEntries(obj, (key, val) => [key, val * val])
+      expect(Obj.isObj(result)).toBe(true)
+      expect(result).toEqual(expected)
+    })
+    
+    it('should work with arrays and return an array', () => {
+      const obj = [1, 2, 3]
+      const expected = [1, 4, 9]
+      const result = Obj.mapEntries(obj, (key, val) => [key, val * val])
+      expect(isArr(result)).toBe(true)
+      expect(result).toEqual(expected)
+    })
+
+    it("should log an error when the cb function does not return an entry", () => {
+      const orgError = console.error
+      console.error = jest.fn()
+
+      const result = Obj.mapEntries({a: 1}, (key, value) => (value * 2))
+      expect(console.error).toHaveBeenCalled()
+
+      // it ignores any entries that don't return an entry when passed into the cb
+      expect(result).toEqual({a: 1})
+      console.error = orgError
+    })
+
+    it("can change keys", () => {
+      const result = Obj.mapEntries({a: 1}, (key, value) => ['b', value])
+      expect(result.b).toEqual(1)
+      expect(result.a).toEqual(undefined)
+    })
+
+    it("should log an error and return the input if the input is invalid", () => {
+      const orgError = console.error
+      console.error = jest.fn()
+      let result = Obj.mapEntries(1, () => {})
+      expect(console.error).toHaveBeenCalled()
+      expect(result).toEqual(1)
+
+      console.error = jest.fn()
+      result = Obj.mapEntries({})
+      expect(console.error).toHaveBeenCalled()
       console.error = orgError
     })
   })

--- a/src/scripts/__tests__/object.js
+++ b/src/scripts/__tests__/object.js
@@ -479,4 +479,26 @@ describe('/object', () => {
       console.error = orgError
     })
   })
+
+  describe("isEntry", () => {
+    it("should return true if the input is an entry, false otherwise", () => {
+      let result = Obj.isEntry([1, 2])
+      expect(result).toBe(true)
+
+      result = Obj.isEntry([1, 2, 3])
+      expect(result).toBe(false)
+
+      result = Obj.isEntry([1])
+      expect(result).toBe(false)
+
+      result = Obj.isEntry({})
+      expect(result).toBe(false)
+
+      result = Obj.isEntry(null)
+      expect(result).toBe(false)
+
+      result = Obj.isEntry([])
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/src/scripts/__tests__/object.js
+++ b/src/scripts/__tests__/object.js
@@ -469,14 +469,15 @@ describe('/object', () => {
     it("should log an error and return the input if the input is invalid", () => {
       const orgError = console.error
       console.error = jest.fn()
-      let result = Obj.mapEntries(1, () => {})
+      const result = Obj.mapEntries(1, () => {})
       expect(console.error).toHaveBeenCalled()
       expect(result).toEqual(1)
 
       console.error = jest.fn()
-      result = Obj.mapEntries({})
+      const nextResult = Obj.mapEntries({})
       expect(console.error).toHaveBeenCalled()
       console.error = orgError
+      expect(nextResult).toEqual({})
     })
   })
 

--- a/src/scripts/__tests__/object.js
+++ b/src/scripts/__tests__/object.js
@@ -483,23 +483,31 @@ describe('/object', () => {
 
   describe("isEntry", () => {
     it("should return true if the input is an entry, false otherwise", () => {
-      let result = Obj.isEntry([1, 2])
-      expect(result).toBe(true)
+      const cases = [
+        [ [1, 2], true ],
+        [ [1, 2, 3], false ],
+        [ [1], false ],
+        [ {}, false ],
+        [ null, false ],
+        [ [], false ],
+      ]
+      cases.map(([entry, expectedResult]) => {
+        const result = Obj.isEntry(entry)
+        expect(result).toBe(expectedResult)
+      })
+    })
 
-      result = Obj.isEntry([1, 2, 3])
-      expect(result).toBe(false)
-
-      result = Obj.isEntry([1])
-      expect(result).toBe(false)
-
-      result = Obj.isEntry({})
-      expect(result).toBe(false)
-
-      result = Obj.isEntry(null)
-      expect(result).toBe(false)
-
-      result = Obj.isEntry([])
-      expect(result).toBe(false)
+    it("should check that the first element is number or string", () => {
+        const cases = [
+          [ ["id", 1], true ],
+          [ [0, "value"], true ],
+          [ [new Date(), "value"], false ],
+          [ [true, "value"], false ],
+        ]
+        cases.map(([entry, expectedResult]) => {
+          const result = Obj.isEntry(entry)
+          expect(result).toBe(expectedResult)
+        })
     })
   })
 })

--- a/src/scripts/array.js
+++ b/src/scripts/array.js
@@ -2,6 +2,8 @@
 
 'use strict'
 
+const { isNum } = require('./number')
+
 /**
  * Randomly selects values from a passed in array.
  * @function
@@ -74,3 +76,30 @@ export const isArr = value => (
 export const cloneArr = arr => (
   Array.from([ ...(isArr(arr) && arr || []) ])
 )
+
+/**
+ * Returns a new array with the same elements as arr, excluding `count` elements beginning at index `startIndex`
+ * @param {Array} arr 
+ * @param {Number} startIndex 
+ * @param {Number} count 
+ */
+export const omitRange = (arr, startIndex, count) => {
+  if (!isArr(arr)) {
+    console.error(`omitRange expected Array. Found ${typeof arr}`)
+    return arr
+  }
+  if (!isNum(startIndex) || startIndex < 0) {
+    console.error(`omitRange expected non-negative startIndex. Found ${startIndex}`)
+    return arr
+  }
+  if (!isNum(count) || count < 0) {
+    console.error(`omitRange expected non-negative count. Found ${count}`)
+    return arr
+  }
+
+  const nextArr = [ ...arr ]
+
+  nextArr.splice(startIndex, count)
+
+  return nextArr
+}

--- a/src/scripts/object.js
+++ b/src/scripts/object.js
@@ -6,6 +6,7 @@ import { logData } from './log'
 import { isFunc, pipeline } from './method'
 import { deepClone, set } from './collection'
 import { sanitize, isStr } from './string'
+import { isNum } from './number'
 import { isArr } from './array'
 import { strToType } from './ext'
 
@@ -201,7 +202,7 @@ export const mapObj = (obj, cb) => (
  * Returns a new object, each entry of which is the result of applying the cb function to input's corresponding entry 
  * @param {Object | Array} obj - regular object or array
  * @param {Function} cb  - function of form: (key, value) => [nextKey, nextValue]
- *  - the return type here is an array of two elements, key and value
+ *  - the return type here is an array of two elements, key and value, where `key` must be either a string or a number
  *  - if a cb does not return an entry, then the original [key, value] pair that was passed into cb will be used instead
  * @returns new object with mapping applied, or the original obj if input was invalid
  * @example mapObj({a: 2, b: 3}, (k, v) => [k, v * v]) returns: {a: 4, b: 9}
@@ -226,7 +227,7 @@ export const mapEntries = (obj, cb) => {
     (obj, [key, value]) => {
       const result = cb(key, value)
       if (!isEntry(result)) {
-        console.error(`Callback function must return entry (2-element array). Found: ${result}. Using current entry instead.`)
+        console.error(`Callback function must return entry. Found: ${result}. Using current entry instead.`)
         return set(obj, key, value)
       } 
       return set(obj, result[0], result[1])
@@ -236,12 +237,18 @@ export const mapEntries = (obj, cb) => {
 }
 
 /**
- * Checks if the input is a valid entry - a 2-element array, like what Object.entries produces
+ * Checks if the input is a valid entry - a 2-element array, like what Object.entries produces.
+ * Expects the first element in the entry to be either a string or a number.
  * @param {*} maybeEntry 
  * @returns true if it is an entry, false otherwise
  * @example isEntry([1, 2]) // true
+ * @example isEntry(["id", 87]) // true
+ * @example isEntry([new Date(), 2]) // false, first element not string or number
+ * @example isEntry([1, 2, 3]) // false, too many elements
  */
-export const isEntry = (maybeEntry) => isArr(maybeEntry) && (maybeEntry.length === 2)
+export const isEntry = (maybeEntry) => isArr(maybeEntry) 
+  && (maybeEntry.length === 2)
+  && (isNum(maybeEntry[0]) || isStr(maybeEntry[0]))
 
 
 /**

--- a/src/scripts/object.js
+++ b/src/scripts/object.js
@@ -214,7 +214,7 @@ export const mapEntries = (obj, cb) => {
   }
 
   if (!isFunc(cb)) {
-    console.error(`Expected function for cb. Found ${typeof obj}`)
+    console.error(`Expected function for cb. Found ${typeof cb}`)
     return obj
   }
 
@@ -226,7 +226,7 @@ export const mapEntries = (obj, cb) => {
     (obj, [key, value]) => {
       const result = cb(key, value)
       if (!isEntry(result)) {
-        console.error(`Callback function must return an entry (2-element array). Found: ${result}. mapEntries will now use the current entry.`)
+        console.error(`Callback function must return entry (2-element array). Found: ${result}. Using current entry instead.`)
         return set(obj, key, value)
       } 
       return set(obj, result[0], result[1])

--- a/src/scripts/object.js
+++ b/src/scripts/object.js
@@ -239,6 +239,7 @@ export const mapEntries = (obj, cb) => {
  * Checks if the input is a valid entry - a 2-element array, like what Object.entries produces
  * @param {*} maybeEntry 
  * @returns true if it is an entry, false otherwise
+ * @example isEntry([1, 2]) // true
  */
 export const isEntry = (maybeEntry) => isArr(maybeEntry) && (maybeEntry.length === 2)
 

--- a/src/scripts/object.js
+++ b/src/scripts/object.js
@@ -391,10 +391,13 @@ export const filterObj = (obj, predicate) => {
     return obj
   } 
 
-  return pipeline(
+  return reduceObj(
     obj,
-    Object.entries,
-    entries => entries.filter(([key, value]) => predicate(key, value)),
-    Object.fromEntries
+    (key, value, data) => {
+      if (predicate(key, value))
+        data[key] = value
+      return data
+    },
+    {}
   )
 }


### PR DESCRIPTION
- Removed use of Object.fromEntries function from my filterObj function, which has limited browser/node support. It was breaking my tests and could be a problem on certain browsers.

- Added the mapEntries function which applies the mapping function to an object (or array) and returns an object (or array) 