### PR TITLE
Limbo and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "deploy": "gh-pages -d docs"
   },
   "dependencies": {
-    "webpack-shell-plugin": "https://github.com/cdeutsch/webpack-shell-plugin.git#bee537d"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
@@ -49,7 +48,8 @@
     "rimraf": "3.0.0",
     "terser-webpack-plugin": "1.3.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.1.2"
+    "webpack-cli": "3.1.2",
+    "webpack-shell-plugin": "https://github.com/cdeutsch/webpack-shell-plugin.git#bee537d"
   },
   "jest": {
     "transform": {

--- a/src/scripts/__tests__/method.js
+++ b/src/scripts/__tests__/method.js
@@ -10,6 +10,12 @@ const promiseHelper = isValid => new Promise((res, rej) => {
   }, 100)
 })
 
+const promiseError = isValid => new Promise((res, rej) => {
+  setTimeout(() => {
+    throw new Error(`Promise Error`)
+  }, 100)
+})
+
 describe('/method', () => {
 
   beforeEach(() => jest.resetAllMocks())
@@ -140,7 +146,6 @@ describe('/method', () => {
     })
 
   })
-  
 
   describe('isFunc', () => {
 
@@ -202,7 +207,7 @@ describe('/method', () => {
       done()
     })
 
-    it('should return an error for first slot when an error is caught', async (done) => {
+    it('should return an error for first slot when the promise is rejected', async (done) => {
       const [ err, data ] = await Method.limbo(promiseHelper(false))
 
       expect(err instanceof Error).toBe(true)
@@ -228,6 +233,14 @@ describe('/method', () => {
     })
 
     it('should return an error for first slot when no promise is passed in', async (done) => {
+      const [ err, data ] = await Method.limbo()
+
+      expect(err instanceof Error).toBe(true)
+
+      done()
+    })
+
+    it('should return an error for first slot when an error is thrown', async (done) => {
       const [ err, data ] = await Method.limbo()
 
       expect(err instanceof Error).toBe(true)

--- a/src/scripts/__tests__/method.js
+++ b/src/scripts/__tests__/method.js
@@ -1,6 +1,14 @@
 
+const { isArr } = require('../array')
 const Method = require('../method')
 
+const promiseHelper = isValid => new Promise((res, rej) => {
+  setTimeout(() => {
+    isValid
+      ? res(`Promise Valid`)
+      : rej(new Error(`Promise Error`))
+  }, 100)
+})
 
 describe('/method', () => {
 
@@ -76,8 +84,59 @@ describe('/method', () => {
   describe('doIt', () => {
 
     it('should execute the callback n times based on passed in param', () => {
+      const callback = jest.fn((index, arr, data) => arr.push(index))
+      Method.doIt(5, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(5)
+    })
+
+    it('should stop call the callback when the last callback returned false', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return false })
+      Method.doIt(3, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('should keep calling the callback when the callback returns falsy but not false', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return undefined })
+      Method.doIt(3, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(3)
+    })
+
+    it('should return an array of response from the return of the callback', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return Math.floor(Math.random() * 10) })
+      const responses = Method.doIt(3, global, [], callback)
       
+      expect(isArr(responses)).toBe(true)
+      expect(responses.length).toBe(3)
+    })
+
+    it('should bind the callback to the second argument', () => {
+      let isBound
+      const callback = jest.fn(function(index, arr, data){ isBound = this === global })
+      Method.doIt(1, global, [], callback)
+
+      expect(isBound).toBe(true)
+    })
+
+    it('should pass all arguments to the callback after first 2, and exclude the last', () => {
+      let has1
+      let has2
+      let has3
+      const callback = jest.fn((index, is1, is2, is3) => {
+        has1 = is1
+        has2 = is2
+        has3 = is3
+      })
+      Method.doIt(1, global, 1, 2, 3, callback)
       
+      expect(has1).toBe(1)
+      expect(has2).toBe(2)
+      expect(has3).toBe(3)
     })
 
   })
@@ -127,6 +186,53 @@ describe('/method', () => {
 
     it('should only call the last method passed to it', () => {
       
+    })
+
+  })
+
+  describe('limbo', () => {
+
+    it('should return an array with the length of 2', async (done) => {
+      const response = await Method.limbo(promiseHelper(true))
+
+      expect(typeof response).toBe('object')
+      expect(isArr(response)).toBe(true)
+      expect(response.length).toBe(2)
+
+      done()
+    })
+
+    it('should return an error for first slot when an error is caught', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(false))
+
+      expect(err instanceof Error).toBe(true)
+      expect(err.message).toEqual(`Promise Error`)
+
+      done()
+    })
+
+    it('should return null for first slot when an error is not throw', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(true))
+
+      expect(err).toBe(null)
+
+      done()
+    })
+
+    it('should return promise response for second slot when error is not throw', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(true))
+
+      expect(data).toEqual(`Promise Valid`)
+
+      done()
+    })
+
+    it('should return an error for first slot when no promise is passed in', async (done) => {
+      const [ err, data ] = await Method.limbo()
+
+      expect(err instanceof Error).toBe(true)
+
+      done()
     })
 
   })
@@ -204,4 +310,5 @@ describe('/method', () => {
       console.error = orgError
     })
   })
+
 })

--- a/src/scripts/method.js
+++ b/src/scripts/method.js
@@ -124,12 +124,19 @@ export const debounce = (func, wait = 250, immediate = false) => {
 export const doIt = (...args) => {
   const params = args.slice()
   const num = params.shift()
+  const bindTo = params.shift()
   const cb = params.pop()
-  if(!isNum(num) || !isFunc(cb)) return
+  if(!isNum(num) || !isFunc(cb)) return []
+  
+  const doItAmount = new Array(num)
+  const responses = []
+  for(let i = 0; i < doItAmount.length; i++){
+    const data = cb.call(bindTo, i, ...params)
+    if (data === false) break
+    responses.push(data)
+  }
 
-  let i = -1
-  while (++i < num)
-    if (cb.call(params[0], i, ...params) === false) break
+  return responses
 }
 
 /**
@@ -236,10 +243,27 @@ export const throttleLast = (func, cb, wait = 100) => {
   }
 }
 
+/**
+ * Adds catch to a promise for better error handling of await functions
+ * @example
+ * const [ err, data ] = await limbo(promiseFunction())
+ * // returns an array
+ * // * err will be undefined if no error was thrown
+ * // * data will be the response from the promiseFunction
+ * @function
+ * @param {Promise} promise - Promise to be resolved
+ * @return {Array} - Slot 1 => error, Slot 2 => response from promise
+ */
+export const limbo = promise => {
+  return !promise || !isFunc(promise.then)
+    ? [ new Error(`A promise or thenable is required as the first argument!`), null]
+    : promise
+      .then(data => [null, data])
+      .catch(err => [err, undefined])
+}
 
 /**
  * Creates a uuid, unique up to around 20 million iterations.
- * <br> Good enough for us
  * @example
  * uuid()
  * // New uuid as a string


### PR DESCRIPTION
  * Added **_limbo_** helper
    * Helper removes the need to wrap `await` in a `try / catch`
      * `const [ err, data ] = await limbo(promiseFunction())`
  * Cleaned up **_doIt_** helper
    * Removed the while loop, which avoids getting caught in an infinite loop
    * Removed the bind to object from the params passed to the callback function
    * Could be a **breaking change**, but I don't think it's being used anywhere
      * If it is, then we can just up the version
  * Added tests for limbo and doIt
    * Added tests for limbo
    * Added some tests for doIt, just for better test coverage
     * There are a number of methods that are still missing tests, so I'll try and add them as I go