### PR TITLE
Add more helpers and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "deploy": "gh-pages -d docs"
   },
   "dependencies": {
-    "webpack-shell-plugin": "https://github.com/cdeutsch/webpack-shell-plugin.git#bee537d"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
@@ -49,7 +48,8 @@
     "rimraf": "3.0.0",
     "terser-webpack-plugin": "1.3.0",
     "webpack": "4.33.0",
-    "webpack-cli": "3.1.2"
+    "webpack-cli": "3.1.2",
+    "webpack-shell-plugin": "https://github.com/cdeutsch/webpack-shell-plugin.git#bee537d"
   },
   "jest": {
     "transform": {

--- a/src/scripts/__tests__/array.js
+++ b/src/scripts/__tests__/array.js
@@ -6,7 +6,35 @@ describe('/array', () => {
 
   describe('cloneArr', () => {
 
-    it('should ', () => {})
+    it('should create a copy of the passed in array', () => {
+      const arr = [ 1, 2, 3 ]
+      const cloned = Arr.cloneArr(arr)
+
+      expect(Array.isArray(cloned)).toBe(true)
+      expect(cloned === arr).toBe(false)
+      arr.map((item, index) => expect(cloned[index] === item))
+
+    })
+
+    it('should handle non array / object arguments by returning an empty array and not throw', () => {
+      const arr = "I am not an array"
+      const cloned = Arr.cloneArr(arr)
+
+      expect(Array.isArray(cloned)).toBe(true)
+      expect(cloned === arr).toBe(false)
+      expect(cloned.length).toBe(0)
+
+    })
+
+    it('should handle object arguments by return an array of entries', () => {
+      const arr = { 1: 1, 2: 2, 3: 3 }
+      const cloned = Arr.cloneArr(arr)
+
+      expect(Array.isArray(cloned)).toBe(true)
+      expect(cloned === arr).toBe(false)
+      cloned.map(([ key, value ], index) => expect(arr[key] === value))
+
+    })
 
   })
 
@@ -23,21 +51,103 @@ describe('/array', () => {
     })
   })
 
-  describe('randomArray', () => {
+  describe('randomArr', () => {
 
-    it('should ', () => {})
+    it('should randomly select values from a passed in array', () => {
+      const arr = [ 1, 4, 5, 3, 7, 'test' ]
+      const random = Arr.randomArr(arr, 3)
+
+      random.map(item => expect(arr.indexOf(item) !== -1).toBe(true))
+
+    })
+
+    it('should arrays with a length equal to the second argument', () => {
+      const arr = [ 1, 4, 5, 3, 7, 'test' ]
+      const random = Arr.randomArr(arr, 3)
+      const random2 = Arr.randomArr(arr, 8)
+      const random3 = Arr.randomArr(arr, 1)
+
+      expect(random.length).toBe(3)
+      expect(random2.length).toBe(8)
+      expect(random3.length).toBe(1)
+
+    })
+
+    it('should return a random array item if no amount is passed in', () => {
+      const arr = [ 1, 4, 5, 3, 7, 'test' ]
+      const random1 = Arr.randomArr(arr)
+      const random2 = Arr.randomArr(arr)
+      const random3 = Arr.randomArr(arr)
+
+      expect(arr.indexOf(random1) !== -1).toBe(true)
+      expect(arr.indexOf(random2) !== -1).toBe(true)
+      expect(arr.indexOf(random3) !== -1).toBe(true)
+
+    })
+
+    it('should return the first argument if its not an array', () => {
+      const arr = { "test": "object" }
+      const random = Arr.randomArr(arr)
+
+      expect(arr === random).toBe(true)
+
+    })
 
   })
 
-  describe('randomizeArray', () => {
+  describe('randomizeArr', () => {
 
-    it('should ', () => {})
+    it('should randomly sort the passed in array', () => {
+      const arr = [ 1, 4, 5, 3, 7, 'test' ]
+      const random1 = Arr.randomizeArr(Array.from(arr))
+      const random1Indexes = random1.map(( value, index ) => index)
+
+      random1.map((item, index) => expect(arr.indexOf(item) !== -1).toBe(true))
+      
+      // It's possible that it randomly set the array to be exactly the same
+      // But the odds are very low that would happen
+      let isDiff
+      random1.map((value, index) => {
+        if(isDiff) return
+        if(value !== arr[index]) isDiff = true
+      })
+
+      expect(isDiff).toBe(true)
+    })
+
+    it('should return the first argument if its not an array', () => {
+      const arr = { "test": "object" }
+      const random = Arr.randomizeArr(arr)
+
+      expect(arr === random).toBe(true)
+
+    })
 
   })
   
   describe('uniqArr', () => {
 
-    it('should ', () => {})
+    it('should remove duplicates from the passed in array', () => {
+      const arr = [ 1, 4, 'test', 1, 7, 'test' ]
+      const uniq = Arr.uniqArr(arr)
+
+      expect(uniq.length == arr.length - 2).toBe(true)
+
+      const checkArr = []
+      uniq.map((value, index) => {
+        expect(checkArr.indexOf(value) === -1)
+        checkArr.push(value)
+      })
+
+    })
+
+    it('should return the first argument if its not an array', () => {
+      const arr = { "test": "object" }
+      const uniq = Arr.uniqArr(arr)
+
+      expect(arr === uniq).toBe(true)
+
+    })
 
   })
 

--- a/src/scripts/__tests__/method.js
+++ b/src/scripts/__tests__/method.js
@@ -10,6 +10,12 @@ const promiseHelper = isValid => new Promise((res, rej) => {
   }, 100)
 })
 
+const promiseError = isValid => new Promise((res, rej) => {
+  setTimeout(() => {
+    throw new Error(`Promise Error`)
+  }, 100)
+})
+
 describe('/method', () => {
 
   beforeEach(() => jest.resetAllMocks())
@@ -140,7 +146,6 @@ describe('/method', () => {
     })
 
   })
-  
 
   describe('isFunc', () => {
 
@@ -202,7 +207,7 @@ describe('/method', () => {
       done()
     })
 
-    it('should return an error for first slot when an error is caught', async (done) => {
+    it('should return an error for first slot when the promise is rejected', async (done) => {
       const [ err, data ] = await Method.limbo(promiseHelper(false))
 
       expect(err instanceof Error).toBe(true)
@@ -228,6 +233,14 @@ describe('/method', () => {
     })
 
     it('should return an error for first slot when no promise is passed in', async (done) => {
+      const [ err, data ] = await Method.limbo()
+
+      expect(err instanceof Error).toBe(true)
+
+      done()
+    })
+
+    it('should return an error for first slot when an error is thrown', async (done) => {
       const [ err, data ] = await Method.limbo()
 
       expect(err instanceof Error).toBe(true)

--- a/src/scripts/__tests__/method.js
+++ b/src/scripts/__tests__/method.js
@@ -1,6 +1,14 @@
 
+const { isArr } = require('../array')
 const Method = require('../method')
 
+const promiseHelper = isValid => new Promise((res, rej) => {
+  setTimeout(() => {
+    isValid
+      ? res(`Promise Valid`)
+      : rej(new Error(`Promise Error`))
+  }, 100)
+})
 
 describe('/method', () => {
 
@@ -76,8 +84,59 @@ describe('/method', () => {
   describe('doIt', () => {
 
     it('should execute the callback n times based on passed in param', () => {
+      const callback = jest.fn((index, arr, data) => arr.push(index))
+      Method.doIt(5, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(5)
+    })
+
+    it('should stop call the callback when the last callback returned false', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return false })
+      Method.doIt(3, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    it('should keep calling the callback when the callback returns falsy but not false', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return undefined })
+      Method.doIt(3, global, [], callback)
+
+      expect(callback).toHaveBeenCalledTimes(3)
+    })
+
+    it('should return an array of response from the return of the callback', () => {
+      let isBound
+      const callback = jest.fn((index, arr, data) => { return Math.floor(Math.random() * 10) })
+      const responses = Method.doIt(3, global, [], callback)
       
+      expect(isArr(responses)).toBe(true)
+      expect(responses.length).toBe(3)
+    })
+
+    it('should bind the callback to the second argument', () => {
+      let isBound
+      const callback = jest.fn(function(index, arr, data){ isBound = this === global })
+      Method.doIt(1, global, [], callback)
+
+      expect(isBound).toBe(true)
+    })
+
+    it('should pass all arguments to the callback after first 2, and exclude the last', () => {
+      let has1
+      let has2
+      let has3
+      const callback = jest.fn((index, is1, is2, is3) => {
+        has1 = is1
+        has2 = is2
+        has3 = is3
+      })
+      Method.doIt(1, global, 1, 2, 3, callback)
       
+      expect(has1).toBe(1)
+      expect(has2).toBe(2)
+      expect(has3).toBe(3)
     })
 
   })
@@ -127,6 +186,53 @@ describe('/method', () => {
 
     it('should only call the last method passed to it', () => {
       
+    })
+
+  })
+
+  describe('limbo', () => {
+
+    it('should return an array with the length of 2', async (done) => {
+      const response = await Method.limbo(promiseHelper(true))
+
+      expect(typeof response).toBe('object')
+      expect(isArr(response)).toBe(true)
+      expect(response.length).toBe(2)
+
+      done()
+    })
+
+    it('should return an error for first slot when an error is caught', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(false))
+
+      expect(err instanceof Error).toBe(true)
+      expect(err.message).toEqual(`Promise Error`)
+
+      done()
+    })
+
+    it('should return null for first slot when an error is not throw', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(true))
+
+      expect(err).toBe(null)
+
+      done()
+    })
+
+    it('should return promise response for second slot when error is not throw', async (done) => {
+      const [ err, data ] = await Method.limbo(promiseHelper(true))
+
+      expect(data).toEqual(`Promise Valid`)
+
+      done()
+    })
+
+    it('should return an error for first slot when no promise is passed in', async (done) => {
+      const [ err, data ] = await Method.limbo()
+
+      expect(err instanceof Error).toBe(true)
+
+      done()
     })
 
   })
@@ -204,4 +310,5 @@ describe('/method', () => {
       console.error = orgError
     })
   })
+
 })

--- a/src/scripts/array.js
+++ b/src/scripts/array.js
@@ -3,38 +3,41 @@
 'use strict'
 
 const { isNum } = require('./number')
+const { isObj } = require('./object')
 
 /**
  * Randomly selects values from a passed in array.
  * @function
  * @example
- * randomArray([1,2,3], 1)
+ * randomArr([1,2,3], 1)
  * // Returns an array with one of the values in the passed in array
  * @param {array} arr - array to select values from
  * @param {number} amount - number of values to select from the array
  * @return {array} - randomly sorted array
  */
-export const randomArray = (arr, amount) => {
-  amount = amount || 1
+export const randomArr = (arr, amount) => {
+  if(!isArr(arr)) return arr
+
+  const useAmount = amount || 1
   const randoms = []
-  for (let i = 0; i < amount; i++) {
+  for (let i = 0; i < useAmount; i++) {
     randoms.push(arr[Math.floor(Math.random() * arr.length)])
   }
 
-  return amount === 1 ? randoms[0] : randoms
+  return !amount ? randoms[0] : randoms
 }
 
 /**
  * Randomly sorts an arrays items.
  * @function
  * @example
- * randomizeArray([1,2,3])
+ * randomizeArr([1,2,3])
  * // Returns an array randomly sorted
  * @param {array} arr - array to randomly sorted
  * @return {array} - randomly sorted array
  */
-export const randomizeArray = arr => (
-  arr.sort(() => (0.5 - Math.random()))
+export const randomizeArr = arr => (
+  !isArr(arr) && arr || arr.sort(() => (0.5 - Math.random()))
 )
 
 /**
@@ -47,7 +50,7 @@ export const randomizeArray = arr => (
  * @return {array} - copy of passed in array, with duplicates removed
  */
 export const uniqArr = arr => (
-  isArr(arr) && arr.filter((e, i, arr) => arr.indexOf(e) == i) || arr
+  !isArr(arr) && arr || arr.filter((e, i, arr) => arr.indexOf(e) == i)
 )
 
 /**
@@ -74,7 +77,10 @@ export const isArr = value => (
  * @return {array} - copy of passed in array
  */
 export const cloneArr = arr => (
-  Array.from([ ...(isArr(arr) && arr || []) ])
+  Array.from([
+    // If arr is not an array or object, just use empty array, so we don't throw!
+    ...(isArr(arr) && arr || isObj(arr) && Object.entries(arr) || [])
+  ])
 )
 
 /**

--- a/src/scripts/method.js
+++ b/src/scripts/method.js
@@ -245,6 +245,7 @@ export const throttleLast = (func, cb, wait = 100) => {
 
 /**
  * Adds catch to a promise for better error handling of await functions
+ * <br> Removes the need for wrapping await in a try / catch
  * @example
  * const [ err, data ] = await limbo(promiseFunction())
  * // returns an array

--- a/src/scripts/method.js
+++ b/src/scripts/method.js
@@ -124,12 +124,19 @@ export const debounce = (func, wait = 250, immediate = false) => {
 export const doIt = (...args) => {
   const params = args.slice()
   const num = params.shift()
+  const bindTo = params.shift()
   const cb = params.pop()
-  if(!isNum(num) || !isFunc(cb)) return
+  if(!isNum(num) || !isFunc(cb)) return []
+  
+  const doItAmount = new Array(num)
+  const responses = []
+  for(let i = 0; i < doItAmount.length; i++){
+    const data = cb.call(bindTo, i, ...params)
+    if (data === false) break
+    responses.push(data)
+  }
 
-  let i = -1
-  while (++i < num)
-    if (cb.call(params[0], i, ...params) === false) break
+  return responses
 }
 
 /**
@@ -236,10 +243,27 @@ export const throttleLast = (func, cb, wait = 100) => {
   }
 }
 
+/**
+ * Adds catch to a promise for better error handling of await functions
+ * @example
+ * const [ err, data ] = await limbo(promiseFunction())
+ * // returns an array
+ * // * err will be undefined if no error was thrown
+ * // * data will be the response from the promiseFunction
+ * @function
+ * @param {Promise} promise - Promise to be resolved
+ * @return {Array} - Slot 1 => error, Slot 2 => response from promise
+ */
+export const limbo = promise => {
+  return !promise || !isFunc(promise.then)
+    ? [ new Error(`A promise or thenable is required as the first argument!`), null]
+    : promise
+      .then(data => [null, data])
+      .catch(err => [err, undefined])
+}
 
 /**
  * Creates a uuid, unique up to around 20 million iterations.
- * <br> Good enough for us
  * @example
  * uuid()
  * // New uuid as a string

--- a/src/scripts/node/__mocks__/test_load_func.js
+++ b/src/scripts/node/__mocks__/test_load_func.js
@@ -1,0 +1,6 @@
+// Test helper to test loading a function
+module.exports = jest.fn((data1, data2, data3) => {
+  return Object.assign({
+    key: "I am a test object"
+  }, data1)
+})

--- a/src/scripts/node/__mocks__/test_load_json.json
+++ b/src/scripts/node/__mocks__/test_load_json.json
@@ -1,0 +1,4 @@
+{
+  "TEST_HELPER": "TO TEST LOADING JSON",
+  "key": "I am a test Object"
+}

--- a/src/scripts/node/__tests__/loadModule.js
+++ b/src/scripts/node/__tests__/loadModule.js
@@ -1,0 +1,79 @@
+const loadModule = require('../loadModule')
+const testFunc = require('../__mocks__/test_load_func')
+const path = require('path')
+
+describe('loadModule', () => {
+
+  beforeEach(() => jest.resetAllMocks())
+
+  it('should accept a string as the first argument', () => {
+    const packageConfig = loadModule('../../../../package.json')
+    
+    expect(typeof packageConfig).toBe('object')
+    expect(packageConfig.name).toBe('jsutils')
+  })
+
+  it('should accept an array as the first argument', () => {
+    const packageConfig = loadModule(['../../../../package.json'])
+    
+    expect(typeof packageConfig).toBe('object')
+    expect(packageConfig.name).toBe('jsutils')
+  })
+
+  it('should load the first found module in the array', () => {
+    const packageConfig = loadModule([
+      // Bad Path
+      '../../package.json',
+      // Bad Path
+      '../../../package.json',
+      // Good Path
+      '../../../../package.json',
+    ])
+    
+    expect(typeof packageConfig).toBe('object')
+    expect(packageConfig.name).toBe('jsutils')
+
+    const loadedModule = loadModule([
+      // Bad Path
+      '../../../package.json',
+      // Good Path
+      '../__mocks__/test_load_json.json',
+      // Good Path - Should not be loaded
+      '../../../../package.json',
+    ])
+    
+    // Should not load the package.json
+    expect(typeof loadedModule).toBe('object')
+    expect(loadedModule.name).toBe(undefined)
+    
+    // Should load the test helper json
+    expect(loadedModule.TEST_HELPER).not.toBe(undefined)
+    expect(typeof loadedModule.TEST_HELPER).toBe('string')
+
+  })
+
+  it('should load a function, and call it with passed in params', () => {
+    const arrObj = [ "array" ]
+    const loadedModule = loadModule(
+      '../__mocks__/test_load_func',
+      {},
+      arrObj,
+      1,
+      'string'
+    )
+
+    expect(testFunc).toHaveBeenCalledWith(arrObj, 1, 'string')
+
+  })
+
+
+  it('should load the module from the passed in rootDir when it exists', () => {
+    const rootDir = path.join(__dirname, '../../../../')
+    const packageConfig = loadModule('./package.json', { rootDir })
+    
+    expect(typeof packageConfig).toBe('object')
+    expect(packageConfig.name).toBe('jsutils')
+
+  })
+
+})

--- a/src/scripts/node/cmd.js
+++ b/src/scripts/node/cmd.js
@@ -1,6 +1,10 @@
+/** @module command */
+
 'use strict'
+
 const { logData, setLogs } = require('../log')
-const { promisify } = require('../promise')
+const { promisify, wait } = require('../promise')
+const { wait } = require('../method')
 const { exec } = require('child_process')
 const cmdExec = promisify(exec)
 const fs = require('fs')
@@ -16,6 +20,7 @@ const ERROR_PREFIX = 'ERROR'
 
 /**
 * Logs a message to the console
+* @function
 * @param {any} message - message to log
 * @param {Object} error - thrown during service account process
 * @param {string} [type='error'] - type of message to log
@@ -28,7 +33,8 @@ const errorHelper = (message, error, type = 'error') => {
 }
 
 /**
-* Logs a message to the condole
+* Logs a message to the console
+* @function
 * @param {string} message - message to be logged
 * @param {string} type - method that shoudl be called  ( log || error || warn )
 * @return { void }
@@ -41,16 +47,11 @@ const logMessage = (message, type = 'log', force) => {
 }
 
 /**
-* Stops execution for a given amount of time
-* @param {number} time
-* @return { void }
-*/
-const wait = time => (new Promise((res, rej) => setTimeout(() => res(true), time)))
-
-/**
-* Gets arguments from the cmd line
-* @return {Object} - converted CMD Line arguments as key / value pair
-*/
+ * Gets arguments from the cmd line
+ * @function
+ *
+ * @return {Object} - converted CMD Line arguments as key / value pair
+ */
 const getArgs = () => {
   return process.argv
     .slice(2)
@@ -76,7 +77,8 @@ const getArgs = () => {
 }
 
 /**
-* Ensures all required arguments exist
+* Ensures all required arguments exist based on passed in error object
+* @function
 * @param {Object} args - passed in arguments
 * @param {Object} errors - error message for required arguments
 * @return { void }
@@ -97,6 +99,7 @@ const validateArgs = (args, errors) => (
 
 /**
 * Makes calls to the cmd line shell
+* @function
 * @param {string} line - command to be run in the shell
 * @return response from the shell
 */
@@ -112,7 +115,8 @@ const cmd = async line => {
 }
 
 /**
-* Copies files to a new location
+* Copies file from one location to another
+* @function
 * @param {string} file - file to be copied
 * @param {string} loc - location to put the copied file
 * @return { void }
@@ -122,11 +126,12 @@ const copyFile = async (file, loc) => await cmd(
 )
 
 /**
-* Ensures a file path exists, if it does not, then it creates it
+* Ensures a folder path exists, if it does not, then it creates it
+* @function
 * @param {string} checkPath - path to check
 * @return {boolean} - if the path exists
 */
-const ensurePath = async checkPath => {
+const ensureFolderPath = async checkPath => {
   try {
     // Check if the path exists, if not, then create it
     const pathExists = fs.existsSync(checkPath)
@@ -139,9 +144,10 @@ const ensurePath = async checkPath => {
 
 /**
 * Writes a file to the local system
+* @function
 * @param {string} path - location to save the file
 * @param {string} data - data to save in the file
-* @return { promies || boolean } - if the file was saved
+* @return { promise || boolean } - if the file was saved
 */
 const writeFile = (filePath, data) => (
   new Promise((req, rej) => fs.writeFile(filePath, data, err => err ? rej(err) : req(true)))
@@ -150,11 +156,10 @@ const writeFile = (filePath, data) => (
 module.exports = {
   cmd,
   copyFile,
-  ensurePath,
+  ensureFolderPath,
   errorHelper,
   getArgs,
   logMessage,
-  wait,
   writeFile,
   validateArgs
 }

--- a/src/scripts/node/index.js
+++ b/src/scripts/node/index.js
@@ -1,0 +1,7 @@
+const loadModule = require('./loadModule')
+const cmd = require('./cmd')
+
+module.exports = {
+  ...cmd,
+  loadModule,
+}

--- a/src/scripts/node/loadModule.js
+++ b/src/scripts/node/loadModule.js
@@ -1,0 +1,140 @@
+/** @module command */
+
+'use strict'
+
+const path = require('path')
+const { isArr } = require('../array')
+const { isFunc } = require('../method')
+const { isObj } = require('../object')
+const { isStr } = require('../string')
+
+const getRelativePath = pathToModule => {
+  const { filename } = module.parent
+  const split = filename.split('/')
+  split.pop()
+
+  return path.resolve(split.join('/'), pathToModule)
+}
+
+/**
+ * Use nodes require method to load a module by file path.
+ * <br> Use the rootDir to load the module if it's passed in
+ * <br> If rootDir + pathToModule fails, will try to load the module without the rootDir
+ * @param {Path|string} pathToModule - Path to the module to load
+ * @param {Object} config - settings to load the module
+ * @param {Path|string} config.rootDir - root directory to load the module from
+ * @param {boolean} config.logErrors - should require errors be logged
+ * @returns {Object|function} - Loaded module
+ */
+const requireModule = (pathToModule, config) => {
+  const { rootDir, logErrors } = config
+  try {
+    // Check if a rootDir exists
+    return rootDir
+      // If rootDir exists, use it to load the module
+      ? require(path.join(rootDir, pathToModule))
+      // If no rootDir, try to load the module without it
+      : require(getRelativePath(pathToModule))
+  }
+  catch(err){
+    // Show errors if set to true
+    logErrors && logData(err.message, `error`)
+
+    // If there's and error, call requireModule again, without the rootDir
+    return rootDir
+      ? requireModule(pathToModule, null)
+      : undefined
+  }
+}
+
+/**
+ * Checks if the module is a function and calls it
+ * <br> Or if it's an object return it
+ * @param {*} foundModule - module loaded from require
+ * @param {*} params - arguments to pass to the module if it's a function
+ * @returns
+ */
+const loadByType = (foundModule, params) => {
+  // Check the type of the foundModule
+  return isFunc(foundModule)
+    // If it's a function call it with params
+    ? foundModule(...params)
+    // If it's an object just return it
+    : isObj(foundModule) || isArr(foundModule)
+      ? foundModule
+      // If it's not a function or object, return undefined
+      : undefined
+}
+
+/**
+ * Loops through the pathsToModule array trying to require them 
+ *
+ * @param {Array} pathsToModule - Potential paths to a module
+ * @param {Object} config - settings to load the module
+ * @param {Path|string} config.rootDir - root directory to load the module from
+ * @param {boolean} config.logErrors - should require errors be logged
+ * @param {Array} params - Arguments to pass the the module when called if it's a function
+ *
+ * @returns {Object} - Loaded module object
+ */
+const loopLoad = (pathsToModule, config, params) => {
+  try {
+    const modulePath = pathsToModule.shift()
+    const foundModule = requireModule(modulePath, config)
+    const loadedModule = foundModule && loadByType(foundModule, params)
+
+    if(!loadedModule) throw new Error(`No Module!`)
+
+    return loadedModule
+  }
+  catch(err){
+    if(!isArr(pathsToModule) || !pathsToModule.length) return undefined
+
+    return loopLoad(pathsToModule, config, params)
+  }
+}
+
+
+/**
+ * Use nodes require method to load a module by file path.
+ * <br> If the path does not exist check the altPaths to see if any of those paths exist
+ * <br> If it's a function call it and pass in the params array
+ * <br> Module path is relative to the caller, NOT this function file location!
+ * @function
+ * @example
+ * const packageConfig = loadModule('../package.json')
+ * @example
+ * const packageConfig = loadModule([ './package.json', '../package.json', '../../package.json', ])
+ * @example
+ * const packageConfig = loadModule([ './package.json' ], { rootDir: 'path to root directory' })
+ * @example
+ * const packageConfig = loadModule([ './functionModule' ], {}, param1, param2, param2)
+ * // Module will be called if it's a function, and param1, param2, param2 will be passed in
+ * @param {Array|string} pathsToModule - Potential paths to a module
+ * @param {Object} config - settings to load the module
+ * @param {Path|string} config.rootDir - root directory to load the module from
+ * @param {boolean} config.logErrors - should require errors be logged
+ * @param {Array} params - Arguments to pass the the module when called if it's a function
+ *
+ * @returns {Object} - Loaded module object
+ */
+const loadModule = (pathsToModule, config={}, ...params) => {
+  
+  // Check If a string is passed in
+  pathsToModule = isStr(pathsToModule)
+    // If it's a string, convert to an array
+    ? [ pathsToModule ]
+    // Otherwise check if it's and array
+    : isArr(pathsToModule) && pathsToModule
+  
+  // Check if there are paths to load
+  return pathsToModule
+    // Call loopLoad to load the module
+    ? loopLoad(pathsToModule, config, params)
+    // If not paths, log an error
+    : lodData(`loadModule requires an array or string as the first argument.`, `error`)
+
+}
+
+
+module.exports = loadModule

--- a/src/scripts/promise.js
+++ b/src/scripts/promise.js
@@ -112,3 +112,11 @@ export const promisifyAll = object => {
 
   return object
 }
+
+/**
+ * Stops execution for a given amount of time
+ * @function
+ * @param {number} time - Amount of time to wait
+ * @return { void }
+ */
+export const wait = time => (new Promise((res, rej) => setTimeout(() => res(true), time)))


### PR DESCRIPTION
### Updates
  * Added **_limbo_** helper
    * Helper removes the need to wrap `await` in a `try / catch`
      * `const [ err, data ] = await limbo(promiseFunction())`
  * Cleaned up **_doIt_** helper
    * Removed the while loop, which avoids getting caught in an infinite loop
    * Removed the bind to object from the params passed to the callback function
    * Could be a **breaking change**, but I don't think it's being used anywhere
  * Added **_loadModule_** helper for node
    * Helps with requiring a module from different possible locations 
    * `const loaded = loadModule([ ...array of possible locations ])`
  * Fixed some issues with **_array_** helpers
    * I noticed the names are not consistent, so I updated them
    * This is a breaking change, so we will need to **update the version**
  * Added more tests
    * Added tests for limbo
    * Added some tests for doIt
    * Added some tests for array helpers
    * There are a number of methods that are still missing tests, so I'll try and add them as I go