### PR TITLE
Collection - shallowEqual

### DIFF
--- a/src/scripts/__tests__/collection.js
+++ b/src/scripts/__tests__/collection.js
@@ -343,4 +343,82 @@ describe('/collection', () => {
     })
   })
 
+  describe('shallowEqual', () => {
+
+    it('should return true when the collections key values are the same', () => {
+      const col1 = { foo: 'bar', baz: 1 }
+      const col2 = { foo: 'bar', baz: 1 }
+
+      expect(col1 === col2).toEqual(false)
+      expect(Coll.shallowEqual(col1, col2)).toEqual(true)
+
+    })
+
+    it('should return true when the collections are the same', () => {
+      const col1 = { foo: 'bar', baz: 1 }
+      const col2 = col1
+
+      expect(col1 === col2).toEqual(true)
+      expect(Coll.shallowEqual(col1, col2)).toEqual(true)
+
+    })
+
+    it('should return true when the objects have the same keys but are not the same', () => {
+      const col1 = { 0: 'foo', 1: 'bar' }
+      const col2 = [ 'foo', 'bar' ]
+      
+      expect(col1 === col2).toEqual(false)
+      expect(Coll.shallowEqual(col1, col2)).toEqual(true)
+
+    })
+
+    it('should return false when the collections key values are NOT the same', () => {
+      const col1 = { foo: 'bar', baz: [] }
+      const col2 = { foo: 'bar' }
+
+      const col3 = { foo: 'bar', baz: [] }
+      const col4 = { foo: 'bar', baz: [] }
+
+      expect(col1 === col2).toEqual(false)
+      expect(Coll.shallowEqual(col1, col2)).toEqual(false)
+
+      expect(col3 === col4).toEqual(false)
+      expect(Coll.shallowEqual(col3, col4)).toEqual(false)
+
+    })
+
+    it('should return false when either of the arguments is not a collection', () => {
+      const col1 = { foo: 'bar', baz: 1 }
+      const col2 = 'FAIL'
+
+      expect(Coll.shallowEqual(col1, col2)).toEqual(false)
+      expect(Coll.shallowEqual(col2, col1)).toEqual(false)
+
+    })
+
+    it('should return false when either of the arguments dont exist', () => {
+      const col1 = { foo: 'bar', baz: 1 }
+      const col2 = undefined
+
+      expect(Coll.shallowEqual(col1, col2)).toEqual(false)
+      expect(Coll.shallowEqual(col2, col1)).toEqual(false)
+
+    })
+
+    it('should compare sub-keys when a path is passed as third argument', () => {
+      const col1 = { foo: { bar: { baz: 'biz' }}}
+      const col2 = { foo: { bar: { baz: 'biz' }}}
+
+      expect(col1 === col2).toEqual(false)
+
+      // Should fail with no path
+      expect(Coll.shallowEqual(col1, col2)).toEqual(false)
+
+      // Pass in the path, to compare sub-key object
+      expect(Coll.shallowEqual(col1, col2, 'foo.bar')).toEqual(true)
+
+    })
+
+  })
+
 })

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -326,7 +326,7 @@ export const shallowEqual = (col1, col2, path) => {
   
   // Loop the keys, and ensure the other collection has the key and it's value is the same
   for (const key in col1)
-    if (!col2[key] || col1[key] !== col2[key]) return false
+    if (col1[key] !== col2[key]) return false
 
   // Keys and values are equal, so return true
   return true

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -5,6 +5,7 @@
 import { isFunc } from './method'
 import { isArr } from './array'
 import { isNum } from './number'
+import { isStr } from './string'
 
 /**
  * Updates a collection by removing, getting, adding to it.
@@ -276,4 +277,57 @@ export const repeat = (element, times, cloneDeep=false) => {
     arr.push(value)
   }
   return arr
+}
+
+
+/**
+ * Compares a collection's keys / values with another collections keys / values
+ * @example
+ * shallowEqual({ foo: 'bar' }, { foo: 'bar' })
+ * // Returns true
+ * @example
+ * shallowEqual({ foo: 'bar', baz: {} }, { foo: 'bar', baz: {} })
+ * // Returns false, because the baz values are different objects
+ * @example
+ * // Works with array too
+ * shallowEqual([ 1, 2 ], [ 1, 2 ])
+ * // Returns true
+ * @example
+ * shallowEqual([{ foo: 'bar' }], [{ foo: 'bar' }])
+ * // Returns false, because the objects in index 0 are different
+ * @example
+ * // Pass a path to compare instead of the root
+ * shallowEqual({ foo: { bar: { baz: 'biz' }}}, { foo: { bar: { baz: 'biz' }}}, 'foo.bar')
+ * // Returns true, because the bar object is compared
+ * @function
+ * @param {Object|Array} col1 - Collection to compare
+ * @param {Object|Array} col2 - Collection to compare
+ * @param {Array|string} path - path of object to compare. Uses the get method to find the path
+ *
+ * @returns {boolean} - true or false if the objects keys values are equal
+ */
+export const shallowEqual = (col1, col2, path) => {
+
+  // If a path is passed in, update the collections to be that path
+  if(path && (isArr(path) || isStr(path) && path.indexOf('.') !== -1 )){
+    col1 = get(col1, path)
+    col2 = get(col2, path)
+  }
+  
+  // If the objects are the same, so return true
+  if(col1 === col2) return true
+
+  // Ensure the objects exist, and they have keys we can compare
+  if (typeof col1 !== "object" || !col1 || typeof col2 !== "object" || !col2)
+    return false
+
+  // If they have different key lengths, then they are not equal
+  if (Object.keys(col1).length !== Object.keys(col2).length) return false
+  
+  // Loop the keys, and ensure the other collection has the key and it's value is the same
+  for (const key in col1)
+    if (!col2[key] || col1[key] !== col2[key]) return false
+
+  // Keys and values are equal, so return true
+  return true
 }

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -309,7 +309,7 @@ export const repeat = (element, times, cloneDeep=false) => {
 export const shallowEqual = (col1, col2, path) => {
 
   // If a path is passed in, update the collections to be that path
-  if(path && (isArr(path) || isStr(path) && path.indexOf('.') !== -1 )){
+  if(path && (isArr(path) || isStr(path))){
     col1 = get(col1, path)
     col2 = get(col2, path)
   }


### PR DESCRIPTION
### Updates
  * Added shallowEqual helper
    * Compares the keys values of two collections

### Notes
  * This will eventually be used in sv-re-theme, to add a theme joiner helper
    * Using this with a memorize, will help speed up renders when using re-theme like this =>
    ```js
      // Example of joining styles together on a component
      <Button
        style={ ReTheme.join(...buttonStyle, ...theme.button, ...theme.extraPad) }
      />
    ```
  * Pull request for sv-re-theme coming shortly
