### PR TITLE
Collection.Get method minor adjust

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ink-docstrap": "1.3.2",
     "jest": "24.7.1",
     "jsdoc": "3.6.3",
+    "lodash": "4.17.15",
     "raw-loader": "2.0.0",
     "remove-comments-loader": "0.1.2",
     "rimraf": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ink-docstrap": "1.3.2",
     "jest": "24.7.1",
     "jsdoc": "3.6.3",
-    "lodash": "4.17.15",
     "raw-loader": "2.0.0",
     "remove-comments-loader": "0.1.2",
     "rimraf": "3.0.0",

--- a/src/scripts/__tests__/collection.js
+++ b/src/scripts/__tests__/collection.js
@@ -8,6 +8,52 @@ describe('/collection', () => {
   
   describe('get', () => {
 
+    it('should return fallback when it sees null || undefined value', () => {
+      const getObj = { 
+        data: undefined  
+      }
+      const path = 'data'
+      expect(Coll.get(getObj, path, 0) === 0).toBe(true)
+
+      const getObj2 = { 
+        data: {
+          foo: {
+            bar: null
+          }
+        }  
+      }
+      const path2 = ['data', 'foo', 'bar']
+      expect(Coll.get(getObj2, path2, 0) === 0).toBe(true)
+
+    })
+
+    it('should NOT modify the traversed path upon failure', () => {
+      const obj = { 
+        foo: 123,
+        data: 'Hello'  
+      }
+      const path = ['data', 'path2']
+
+      // path2 doesn't exist, should return fallback value
+      expect(Coll.get(obj, path, 0) === 0).toBe(true)
+      // traversed path should keep its value
+      expect(obj.foo).toEqual(123)
+      expect(obj.data).toEqual('Hello')
+
+      const obj2 = { 
+        foo: 123,
+        data: {
+          count: 100
+        }  
+      }
+      const path2 = ['data', 'count', 'toes']
+
+      expect(Coll.get(obj2, path2, 0) === 0).toBe(true)
+      // traversed path should keep its value
+      expect(obj2.foo).toEqual(123)
+      expect(obj2.data.count).toEqual(100)
+    })
+
     it('should get a value on an object', () => {
       const getObj = { data: [ { foo: 'duper' } ] }
       const path = 'data'

--- a/src/scripts/__tests__/collection.js
+++ b/src/scripts/__tests__/collection.js
@@ -8,25 +8,6 @@ describe('/collection', () => {
   
   describe('get', () => {
 
-    it('should return fallback when it sees null || undefined value', () => {
-      const getObj = { 
-        data: undefined  
-      }
-      const path = 'data'
-      expect(Coll.get(getObj, path, 0) === 0).toBe(true)
-
-      const getObj2 = { 
-        data: {
-          foo: {
-            bar: null
-          }
-        }  
-      }
-      const path2 = ['data', 'foo', 'bar']
-      expect(Coll.get(getObj2, path2, 0) === 0).toBe(true)
-
-    })
-
     it('should NOT modify the traversed path upon failure', () => {
       const obj = { 
         foo: 123,

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -6,7 +6,7 @@ import { isFunc } from './method'
 import { isArr } from './array'
 import { isNum } from './number'
 import { isStr } from './string'
-
+import { cloneDeep } from 'lodash'
 /**
  * Updates a collection by removing, getting, adding to it.
  * @memberof collection
@@ -20,7 +20,8 @@ const updateColl = (obj, path, type, val) => {
   if (!isColl(obj) || !obj || !path)
     return type !== 'set' && val || undefined
   
-  const parts = isArr(path) ? path : path.split('.')
+  // cloneDeep so we don't modify the reference
+  const parts = isArr(path) ? cloneDeep(path) : path.split('.')
   const key = parts.pop()
   let prop
   let breakPath
@@ -29,8 +30,10 @@ const updateColl = (obj, path, type, val) => {
     isColl(obj[prop])
       ? ( obj = obj[prop] )
       : (() => {
+
           if(type !== 'set') breakPath = true
-          obj[prop] = {}
+          // only if obj[prop] has no value, set as empty obj
+          if (obj[prop] == null) obj[prop] = {}
           obj = obj[prop]
         })()
 
@@ -39,7 +42,7 @@ const updateColl = (obj, path, type, val) => {
 
   return type === 'get'
     // Get return the value
-    ? key in obj
+    ? key in obj && obj[key] != null
       ? obj[key]
       : val
     : type === 'unset'

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -6,7 +6,7 @@ import { isFunc } from './method'
 import { isArr } from './array'
 import { isNum } from './number'
 import { isStr } from './string'
-import { cloneDeep } from 'lodash'
+
 /**
  * Updates a collection by removing, getting, adding to it.
  * @memberof collection
@@ -21,7 +21,7 @@ const updateColl = (obj, path, type, val) => {
     return type !== 'set' && val || undefined
   
   // cloneDeep so we don't modify the reference
-  const parts = isArr(path) ? cloneDeep(path) : path.split('.')
+  const parts = isArr(path) ? Array.from(path) : path.split('.')
   const key = parts.pop()
   let prop
   let breakPath
@@ -30,10 +30,8 @@ const updateColl = (obj, path, type, val) => {
     isColl(obj[prop])
       ? ( obj = obj[prop] )
       : (() => {
-
-          if(type !== 'set') breakPath = true
-          // only if obj[prop] has no value, set as empty obj
-          if (obj[prop] == null) obj[prop] = {}
+          if(type === 'set') obj[prop] = {}
+          else breakPath = true
           obj = obj[prop]
         })()
 
@@ -42,7 +40,7 @@ const updateColl = (obj, path, type, val) => {
 
   return type === 'get'
     // Get return the value
-    ? key in obj && obj[key] != null
+    ? key in obj
       ? obj[key]
       : val
     : type === 'unset'


### PR DESCRIPTION
Ticket: https://jira.simpleviewtools.com/browse/ZOP-260

Context:
- see context on ticket description

Update:
- added lodash for deepClone (not really necessary, can remove if we have our own method for this, or replace it once we do have own method)
- adjust for edge case on default value of null || undefined
- adjust for edge case on modifying the reference upon using 'get'