### PR TITLE
Collection.get fixes

### DIFF
--- a/src/scripts/__tests__/collection.js
+++ b/src/scripts/__tests__/collection.js
@@ -62,7 +62,16 @@ describe('/collection', () => {
 
       expect(Coll.get(getObj, path) === 'duper').toBe(true)
     })
-    
+
+    it('should handle functions in the object path', () => {
+      const foo = () => {}
+      foo.boo = 'duper'
+      const getObj = [ { foo } ]
+      const path = '0.foo.boo'
+
+      expect(Coll.get(getObj, path) === 'duper').toBe(true)
+    })
+
     it('should return a fallback when get value does not exist', () => {
       const getObj = { data: [ { foo: 'duper' } ] }
       const path = 'data.0.duper'

--- a/src/scripts/collection.js
+++ b/src/scripts/collection.js
@@ -27,12 +27,14 @@ const updateColl = (obj, path, type, val) => {
   let breakPath
 
   while (prop = parts.shift()) {
-    isColl(obj[prop])
-      ? ( obj = obj[prop] )
+    const next = obj[prop]
+
+    isColl(next) || isFunc(next)
+      ? ( obj = next )
       : (() => {
           if(type === 'set') obj[prop] = {}
           else breakPath = true
-          obj = obj[prop]
+          obj = next
         })()
 
     if (breakPath) return val


### PR DESCRIPTION
  * Fixes issue where functions in an object path can have properties, but breaks get calls
  * Allow functions to be searched when property path is on the function
  * Added test for searching function properties